### PR TITLE
Add Twilio server command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ There are two main patterns demonstrated:
 - This is a Next.js typescript app. Install dependencies with `npm i`.
 - Add your `OPENAI_API_KEY` to your env. Either add it to your `.bash_profile` or equivalent, or copy `.env.sample` to `.env` and add it there.
 - Start the server with `npm run dev`
+- Start the Twilio server with `npm run twilio:server`
 - Open your browser to [http://localhost:3000](http://localhost:3000). It should default to the `chatSupervisor` Agent Config.
 - You can change examples via the "Scenario" dropdown in the top right.
 

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "realtime-examples",
   "version": "0.1.0",
   "private": true,
-  "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint"
+    "scripts": {
+      "dev": "next dev",
+      "build": "next build",
+      "start": "next start",
+      "lint": "next lint",
+      "twilio:server": "ts-node scripts/twilioServer.ts"
   },
   "dependencies": {
     "@openai/agents": "^0.0.1",


### PR DESCRIPTION
## Summary
- add `twilio:server` script to `package.json`
- document running Twilio server in the setup section of the README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c254304d88326a82b6836d01ca79d